### PR TITLE
Add mic access info feature

### DIFF
--- a/src/cam.rs
+++ b/src/cam.rs
@@ -1,6 +1,6 @@
 use crate::fuser::{fusers, pid_name};
 
-/// List out all camera sources that can provide outsie view
+/// List out all camera sources that can provide outside view
 /// This may be a web cam, or HDMI port that support video input even though it doesn't have any
 /// camera
 pub fn get_cam_devices() -> Vec<String> {
@@ -22,7 +22,7 @@ pub fn get_cam_devices() -> Vec<String> {
     cam_devices
 }
 
-/// Accumulates all PIDs that are using all camera vaialable on the system
+/// Accumulates all PIDs that are using all camera available on the system
 pub fn pid_using_camera() -> Vec<i32> {
     let mut pids = Vec::new();
     for cam in get_cam_devices() {
@@ -40,4 +40,10 @@ pub fn proc_using_camera() -> Vec<String> {
         processes.push(pid_name(pid).unwrap_or(format!("Unknow PID {}", pid)));
     }
     processes
+}
+
+#[test]
+fn test_cam_usage() {
+    let procs = proc_using_camera();
+    println!("{procs:#?}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@
 
 pub mod cam;
 pub(crate) mod fuser;
+pub mod mic;

--- a/src/mic.rs
+++ b/src/mic.rs
@@ -1,0 +1,48 @@
+use crate::fuser::{fusers, pid_name};
+
+/// List out all microphone sources that can provide sound input
+/// This can be integrated mic, or HDMI input etc.
+pub fn get_mic_devices() -> Vec<String> {
+    let paths = std::fs::read_dir("/dev/snd");
+    if paths.is_err() {
+        tracing::warn!(
+            "Devicess are not found on this machine, Maybe you're running in chroot environment"
+        );
+        return vec![];
+    }
+    let mut mic_devices = Vec::new();
+    let paths = paths.unwrap();
+    for path in paths.flatten() {
+        let path_str = path.path().display().to_string();
+        if path_str.contains("pcm") || path_str.contains("hw") {
+            mic_devices.push(path_str);
+        }
+    }
+    mic_devices
+}
+
+/// Accumulates all PIDs that are using all microphone available on the system
+pub fn pid_using_mic() -> Vec<i32> {
+    let mut pids = std::collections::HashSet::new();
+    for cam in get_mic_devices() {
+        let pid = fusers(cam.as_str());
+        pids.extend(pid.iter());
+    }
+    pids.into_iter().collect()
+}
+
+/// Accumulates names of all processes using the microphone
+pub fn proc_using_mic() -> Vec<String> {
+    let pids = pid_using_mic();
+    let mut processes = Vec::with_capacity(pids.len());
+    for pid in pids {
+        processes.push(pid_name(pid).unwrap_or(format!("Unknow PID {}", pid)));
+    }
+    processes
+}
+
+#[test]
+fn test_mic_usage() {
+    let procs = proc_using_mic();
+    println!("{procs:#?}");
+}


### PR DESCRIPTION
We can query which process is accessing the camera device, It'll be `pulseaudio` or `pipewire` for most of distros out there